### PR TITLE
fix overflow for long code snippet examples

### DIFF
--- a/css/common.sass
+++ b/css/common.sass
@@ -184,6 +184,7 @@ ul.well
   border-radius: 4px
   border: 1px solid #E2DBDF
   color: #c7254e
+  overflow-x: auto;
   background-color: #f9f2f4
   i.fa
     margin-top: 0.3em


### PR DESCRIPTION
Fixing an issue that bubbled up through #dev-exp channel:

https://socrata.slack.com/archives/C027XUA5H/p1493989427970910



https://files.slack.com/files-tmb/T0271VB20-F596CCZ19-f18f724d2f/pasted_image_at_2017_05_05_09_03_am_720.png