### PR TITLE
EN-81401: update foundry to soda3

### DIFF
--- a/css/common.sass
+++ b/css/common.sass
@@ -293,6 +293,8 @@ ul.well
   background-color: #f9f2f4
   i.fa
     margin-top: 0.3em
+  .http-post
+    padding: 1em
   code
     position: relative
     top: 50%

--- a/js/lib/tryit.js
+++ b/js/lib/tryit.js
@@ -202,6 +202,8 @@ define(
         });
         var default_format = _.findWhere(formats, { extension: format });
 
+        var copy_text = display_url;
+
         // Render our Mustache template
         var content = Mustache.render(template[0], {
           url: href,
@@ -209,7 +211,8 @@ define(
           hurl_url : hurl_url,
           doc_url: doc_url,
           formats: formats,
-          default_format: default_format
+          default_format: default_format,
+          copy_text: copy_text
         });
 
         // Set up the live link and format clicks

--- a/js/lib/tryit.js
+++ b/js/lib/tryit.js
@@ -12,20 +12,7 @@ define(
 
     var matchesV3 = the_href.match(SODA_V3_REGEX);
     var ajaxOptions = matchesV3 ? {
-      url: the_href,
-      method: 'POST',
-      data: JSON.stringify({
-        query: 'select *',
-        page: {
-          pageNumber: 1,
-          pageSize: 10,
-        },
-        includeSynthetic: false,
-      }),
-      headers: {
-        'X-App-Token': 'bHWsGtRFRP9x8Hl8lYivqM1hQ',
-        'Content-Type': 'application/json'
-      },
+      url: the_href.replace('$YOUR_APP_TOKEN', 'bHWsGtRFRP9x8Hl8lYivqM1hQ'),
       dataType: 'text'
     } : {
       url: the_href,

--- a/js/lib/tryit.mst
+++ b/js/lib/tryit.mst
@@ -20,6 +20,9 @@
       </ul>
     </div>
   </div>
+  <div class="http-post">
+    While this macro functions via HTTP GET, it is recommended that you use HTTP POST instead, as specified on <a href="/docs/queries/">this page</a>, in order to access the full range of request options and to allow for very long query texts.
+  </div>
 
   <div class="the-link">
     <i class="fa fa-fw fa-cog"><!-- This Space Left Blank --></i>

--- a/js/lib/tryit.mst
+++ b/js/lib/tryit.mst
@@ -5,7 +5,7 @@
 
       <a class="btn btn-default doc-it has-tooltip ga-track" data-toggle="tooltip" title="" target="_blank" href="{{doc_url}}" data-original-title="View API documentation for this dataset" data-placement="left" data-container="body" data-tracking-category="tryit" data-category-label="docs" data-tracking-value="{{docs_url}}"><i class="fa fa-book"><!-- This Space Left Blank --></i> docs</a>
 
-      <a class="btn btn-default copy-it has-tooltip ga-track" data-toggle="tooltip" title="" target="_blank" data-original-title="Copy this URL to the clipboard" data-placement="left" data-container="body" data-tracking-category="tryit" data-category-label="copy" data-tracking-value="{{display_url}}" data-clipboard-text="{{display_url}}"><i class="fa fa-clipboard"><!-- This Space Left Blank --></i> copy</a>
+      <a class="btn btn-default copy-it has-tooltip ga-track" data-toggle="tooltip" title="" target="_blank" data-original-title="Copy this URL to the clipboard" data-placement="left" data-container="body" data-tracking-category="tryit" data-category-label="copy" data-tracking-value="{{display_url}}" data-clipboard-text="{{copy_text}}"><i class="fa fa-clipboard"><!-- This Space Left Blank --></i> copy</a>
 
       <a class="btn btn-default btn-last format-it ga-track dropdown-toggle" data-toggle="dropdown" title="" target="_blank" href="#" data-original-title="" data-hurl-full-url="{{url}}" data-placement="left" data-container="body" data-tracking-category="tryit" data-category-label="formats" data-tracking-value="formats" aria-haspopup="true" aria-expanded="false">
         <i class="fa fa-code"><!-- This Space Left Blank --></i>


### PR DESCRIPTION
Okay, this PR is doing two-plus-one things:
- First, changed the TryIt macro back to using a GET for SODA3. This is less than ideal, but it's what product has decided is the best path forward for now.
- Then, added the "HTTP POST" block so that there's a _chance_ people will realize they should not be following the examples and instead using a POST call.

This sucks, but frankly, retooling the TryIt macro for doing POST things is a bunch of design work on top of a bunch of JS/CSS work and we don't have the bandwidth for it.

Bonus item:
- There's some support for the copy text being different from the displayed url. I ended up not needing to use this (the idea was that copy-to-clipboard would put a cURL invocation in your pasteboard, for the POST), but I felt like the groundwork was worth leaving in.